### PR TITLE
Update footer with new mailing address for Dragons

### DIFF
--- a/src/app/_components/layout/footer.tsx
+++ b/src/app/_components/layout/footer.tsx
@@ -205,11 +205,11 @@ export default function Footer() {
               Prepare for the future. Just say the magic word: ready for a
               sprint?
             </p>
-            <p className="relative mt-4 block text-lg">Address:</p>
-            <p className="relative block text-lg">
-              USA Inc. (HQ), 1309 Coffeen Avenue, STE 1200, Sheridan, WY 82801,
-              USA
-            </p>
+            <p className="relative mt-4 block text-lg">Mailing Address:</p>
+            <address className="relative block text-lg">
+              <p className="mt-2">30 N Gould St Ste R</p>
+              <p className="mt-2">Sheridan, Wyoming 82801</p>
+            </address>
 
             <p className="mt-4 max-w-xs font-bold text-white">
               <span className="relative text-lg">


### PR DESCRIPTION
Replace the old address in the footer with the new mailing address for Dragons as specified in issue #40. The changes ensure accurate contact information is displayed. Fixes #40